### PR TITLE
Moved ReadSource to read_source.py 

### DIFF
--- a/varlens/evaluation.py
+++ b/varlens/evaluation.py
@@ -45,11 +45,12 @@ STANDARD_EVALUATION_ENVIRONMENT = {
     "numpy": numpy,
 }
 
+
 def parse_url_fragment(url):
     parsed = urlparse(url)
     try:
         if parsed.fragment:
-            # If our fragment begins with an '&' symbol, we ignore it. 
+            # If our fragment begins with an '&' symbol, we ignore it.
             unparsed_fragment = parsed.fragment
             if unparsed_fragment.startswith("&"):
                 unparsed_fragment = unparsed_fragment[1:]
@@ -62,6 +63,7 @@ def parse_url_fragment(url):
 
     return (parsed._replace(fragment='').geturl(), fragment)
 
+
 def string_to_boolean(s):
     value = str(s).lower()
     if value in ("true", "1"):
@@ -69,6 +71,7 @@ def string_to_boolean(s):
     elif value in ("false", 0):
         return False
     raise ValueError("Not a boolean string: %s" % s)
+
 
 class EvaluationEnvironment(object):
     def __init__(self, wrapped_list, extra={}):
@@ -94,10 +97,10 @@ class EvaluationEnvironment(object):
             binding for binding in all_bindings
             if not binding.startswith("_")
         ]
-        return ("<Environment with bindings: %s>"
-            % " ".join(sorted(display_bindings)))
+        return ("<Environment with bindings: %s>" % " ".join(sorted(display_bindings)))
 
 RAISE = object()
+
 
 def evaluate_expression(expression, bindings, error_value=RAISE):
     typechecks.require_string(expression)
@@ -105,11 +108,11 @@ def evaluate_expression(expression, bindings, error_value=RAISE):
     # Since Python 2 doesn't have a nonlocal keyword, we have to box up the
     # error_value, so we can reassign to it in the ``on_error`` function
     # below.
-    error_box = [error_value] 
+    error_box = [error_value]
     try:
         # Give some basic modules.
         standard_environment = dict(STANDARD_EVALUATION_ENVIRONMENT)
-    
+
         # Add our "on_error" hack.
         def on_error(value):
             error_box[0] = value
@@ -123,6 +126,7 @@ def evaluate_expression(expression, bindings, error_value=RAISE):
             expression, bindings)
         traceback = sys.exc_info()[2]
         raise_(ValueError, str(e) + "\n" + extra, traceback)
+
 
 def parse_labeled_expression(labeled_expression):
     match = re.match(r"^([\w ]+):(.*)$", labeled_expression)

--- a/varlens/read_source.py
+++ b/varlens/read_source.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2015. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import functools
+
+import pyensembl
+import pysam
+
+from . import read_evidence
+from .read_source_helpers import alignment_key, evaluate_read_expression
+
+
+class ReadSource(object):
+    def __init__(self, name, filename, read_filters=[]):
+        self.name = name
+        self.filename = filename
+        self.handle = pysam.Samfile(filename)
+        self.read_filters = read_filters
+
+        self.chromosome_name_map = {}
+        for name in self.handle.references:
+            normalized = pyensembl.locus.normalize_chromosome(name)
+            self.chromosome_name_map[normalized] = name
+            self.chromosome_name_map[name] = name
+
+    def index_if_needed(self):
+        if self.filename.endswith(".bam") and not self.handle.has_index():
+            # pysam strangely requires and index even to iterate through a bam.
+            logging.info(
+                "Attempting to create BAM index for file: %s" % self.filename)
+            samtools_output = pysam.index(self.filename)
+            logging.info(
+                "Done indexing" + ((": " + samtools_output) if samtools_output else ''))
+
+            # Reopen
+            self.handle.close()
+            self.handle = pysam.Samfile(self.filename)
+
+    def reads(self, loci=None):
+        if loci is None:
+            def reads_iterator():
+                return self.handle.fetch(until_eof=True)
+        elif self.filename.endswith(".sam"):
+            # Inefficient.
+            chromosome_intervals = {}
+            for (contig, intervals) in loci.contigs.items():
+                try:
+                    chromosome = self.chromosome_name_map[contig]
+                except KeyError:
+                    logging.warn(
+                        "No such contig in bam: %s" % contig)
+                    continue
+                chromosome_intervals[chromosome] = intervals
+
+            def reads_iterator():
+                seen = set()
+                for read in self.handle.fetch(until_eof=True):
+                    intervals = chromosome_intervals.get(read.reference_name)
+                    if not intervals or not intervals.overlaps_range(
+                            read.reference_start,
+                            read.reference_end):
+                        continue
+                    key = alignment_key(read)
+                    if key not in seen:
+                        yield read
+                        seen.add(key)
+        else:
+            self.index_if_needed()
+
+            def reads_iterator():
+                seen = set()
+                for locus in loci:
+                    try:
+                        chromosome = self.chromosome_name_map[locus.contig]
+                    except KeyError:
+                        logging.warn(
+                            "No such contig in bam: %s" % locus.contig)
+                        continue
+                    for read in self.handle.fetch(
+                            chromosome,
+                            locus.start,
+                            locus.end):
+                        key = alignment_key(read)
+                        if key not in seen:
+                            yield read
+                            seen.add(key)
+
+        for alignment in reads_iterator():
+            if all(evaluate_read_expression(expression, alignment)
+                    for expression in self.read_filters):
+                yield alignment
+
+    def pileups(self, loci):
+        self.index_if_needed()
+        collection = read_evidence.PileupCollection.from_bam(self.handle, loci)
+        if self.read_filters:
+            for (locus, pileup) in collection.pileups.items():
+                def evaluate(expression, element):
+                    return evaluate_read_expression(
+                        expression, element.alignment)
+                collection.pileups[locus] = pileup.filter([
+                    functools.partial(evaluate, expression)
+                    for expression in self.read_filters
+                ])
+        return collection

--- a/varlens/read_source_helpers.py
+++ b/varlens/read_source_helpers.py
@@ -1,0 +1,83 @@
+import typechecks
+
+from . import evaluation
+
+
+def evaluate_read_expression(
+        expression,
+        alignment,
+        error_value=evaluation.RAISE,
+        extra_bindings={}):
+
+    if typechecks.is_string(expression):
+        bindings = evaluation.EvaluationEnvironment(
+            [alignment],
+            extra={})
+        return evaluation.evaluate_expression(
+            expression,
+            bindings,
+            error_value=error_value)
+    else:
+        return expression(alignment)
+
+
+def evaluate_pileup_element_expression(
+        expression,
+        collection,
+        pileup,
+        element,
+        error_value=evaluation.RAISE,
+        extra_bindings={}):
+
+    if typechecks.is_string(expression):
+        bindings = evaluation.EvaluationEnvironment(
+            [element, element.alignment, pileup],
+            extra={
+                'element': element,
+                'pileup': pileup,
+                'collection': collection,
+            })
+        return evaluation.evaluate_expression(
+            expression,
+            bindings,
+            error_value=error_value)
+    else:
+        return expression(pileup)
+
+
+def alignment_key(pysam_alignment_record):
+    '''
+    Return the identifying attributes of a `pysam.AlignedSegment` instance.
+    This is necessary since these objects do not support a useful notion of
+    equality (they compare on identify by default).
+    '''
+    return (
+        read_key(pysam_alignment_record),
+        pysam_alignment_record.query_alignment_start,
+        pysam_alignment_record.query_alignment_end,
+    )
+
+
+def read_key(pysam_alignment_record):
+    '''
+    Given a `pysam.AlignedSegment` instance, return the attributes identifying
+    the *read* it comes from (not the alignment). There may be more than one
+    alignment for a read, e.g. chimeric and secondary alignments.
+    '''
+    return (
+        pysam_alignment_record.query_name,
+        pysam_alignment_record.is_duplicate,
+        pysam_alignment_record.is_read1,
+        pysam_alignment_record.is_read2,
+    )
+
+
+def flatten_header(header):
+    for (group, rows) in header.items():
+        for (index, row) in enumerate(rows):
+            if not isinstance(row, dict):
+                key_values = [(row, "")]
+            else:
+                key_values = row.items()
+            for (key, value) in key_values:
+                yield (str(group), index, str(key), str(value))


### PR DESCRIPTION
If I have to understand `ReadSource`'s methods then it seems cleaner to give that class its own file rather than having a cluttered `reads_util` module with a lot of semi-related functionality. 