### PR TITLE
Drop url parsing logic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ if __name__ == '__main__':
         ],
         install_requires=[
             'numpy',
-            'matplotlib',
             'intervaltree',
             'pysam>=0.8.4',
             'typechecks',

--- a/test/test_allele_support.py
+++ b/test/test_allele_support.py
@@ -68,7 +68,8 @@ def test_basic():
 def test_simple():
     result = run([
         "--reads", data_path("CELSR1/bams/bam_0.bam"),
-        "--variants", data_path("CELSR1/vcfs/vcf_1.vcf#genome=b37"),
+        "--variant-genome", "b37",
+        "--variants", data_path("CELSR1/vcfs/vcf_1.vcf"),
     ])
     eq_(cols_concat(
             result,
@@ -91,7 +92,8 @@ def test_simple():
     for variant_filter in pick_one_variant:
         result = run([
             "--reads", data_path("CELSR1/bams/bam_0.bam"),
-            "--variants", data_path("CELSR1/vcfs/vcf_1.vcf#genome=b37"),
+            "--variant-genome", "b37",
+            "--variants", data_path("CELSR1/vcfs/vcf_1.vcf"),
             "--variant-filter", variant_filter,
         ])
         yield (

--- a/test/test_reads.py
+++ b/test/test_reads.py
@@ -87,6 +87,30 @@ def test_loci_filtering():
     ])
     eq_(result.shape, (1753, len(expected_cols)))
 
+def test_read_filtering():
+    result = run([
+        "--reads", data_path("CELSR1/bams/bam_5.bam"),
+        "--read-filter", 'reference_start == 46932059',
+    ])
+    eq_(result.shape, (26, len(expected_cols)))
+
+    result = run([
+        "--reads", data_path("CELSR1/bams/bam_5.bam"),
+        "--read-filter", 'reference_start == 46932059',
+        "--read-filter", 'query_name.split(":")[-1] == "57841"',
+    ])
+    eq_(result.shape, (1, len(expected_cols)))
+
+    result = run([
+        "--reads",
+        data_path("CELSR1/bams/bam_5.bam"),
+        data_path("CELSR1/bams/bam_6.bam"),
+        "--read-filter",
+        'reference_start == 46932059',
+        'reference_start == 46931732',
+        "--read-filter", 'int(query_name.split(":")[-1]) % 3 == 0',
+    ])
+    eq_(result.shape, (14, len(expected_cols)))
 
 def test_round_trip():
     with temp_file(".bam") as out:

--- a/varlens/__init__.py
+++ b/varlens/__init__.py
@@ -16,10 +16,11 @@ from __future__ import absolute_import
 
 from .locus import Locus
 from .loci_util import Loci
-from . import read_evidence
+from . import read_evidence, util
 
 __all__ = [
     "Loci",
     "Locus",
     "read_evidence",
+    "util",
 ]

--- a/varlens/util.py
+++ b/varlens/util.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2015. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+def expand(value, arg_name, input_name, length):
+    if value is None or len(value) == 0:
+        return [None] * length
+
+    if len(value) == length:
+        return value
+
+    if len(value) == 1:
+        return value * length
+
+    if length == 1:
+        raise ValueError(
+            "With only 1 {input_name} specified, each {arg_name} argument "
+            "should be length 1. If you are trying to specify multiple filters"
+            " to apply consecutively, you should specify the entire argument "
+            "multiple times."
+            .format(
+                arg_name=arg_name,
+                input_name=input_name,
+                length=length,
+                actual=len(value)))
+
+    else:
+        raise ValueError(
+            "Expected argument {arg_name} to be length 1 (i.e. apply to all "
+            "{input_name} inputs) or length {length} (i.e. an individual value"
+            " for each of the {length} {input_name} inputs), not {actual}."
+            .format(
+                arg_name=arg_name,
+                input_name=input_name,
+                length=length,
+                actual=len(value)))
+
+
+def drop_prefix(strings):
+    """
+    Removes common prefix from a collection of strings
+    """
+    if len(strings) == 1:
+        return [os.path.basename(strings[0])]
+    prefix_len = len(os.path.commonprefix(strings))
+    return [string[prefix_len:] for string in strings]


### PR DESCRIPTION
First of several cleanups. We used to support specifying VCFs and BAMs with
attributes, like '/path/to/file.bam#filter="I" in cigarstring'. That can be
somewhat convenient (especially when dealing with multple files with different
filters) but also awkward to explain and error prone. Got rid of that logic.
Now everything is in individual arguments.